### PR TITLE
Fix task list for multiple post types

### DIFF
--- a/publishing-checklist.php
+++ b/publishing-checklist.php
@@ -124,7 +124,7 @@ class Publishing_Checklist {
 		}
 
 		$checklist_data = array(
-			'tasks'     => $this->tasks,
+			'tasks'     => $tasks,
 			'completed' => $completed_tasks,
 		);
 

--- a/publishing-checklist.php
+++ b/publishing-checklist.php
@@ -191,7 +191,7 @@ class Publishing_Checklist {
 				unset( $this->tasks[ $task_id ] );
 			}
 
-			if ( ! empty( $task['post_type'] ) && ! in_array( get_post_type(), $task['post_type'] ) ) {
+			if ( ! empty( $task['post_type'] ) && ! in_array( get_post_type(), $task['post_type'], true ) ) {
 				unset( $this->tasks[ $task_id ] );
 			}
 		}

--- a/publishing-checklist.php
+++ b/publishing-checklist.php
@@ -95,29 +95,36 @@ class Publishing_Checklist {
 			return false;
 		}
 
-		$post_type = get_post_type( $post_id );
-
+		$tasks           = array();
 		$completed_tasks = array();
+
+		// Get all tasks to be run for this post_id.
 		foreach ( $this->tasks as $task_id => $task ) {
+
 			if ( ! is_callable( $task['callback'] ) ) {
-				unset( $this->tasks[ $task_id ] );
+				continue;
 			}
 
-			if ( ! empty( $task['post_type'] ) && ! in_array( $post_type, $task['post_type'] ) ) {
-				unset( $this->tasks[ $task_id ] );
+			if ( empty( $task['post_type'] ) || ! in_array( get_post_type( $post_id ), $task['post_type'] ) ) {
+				continue;
 			}
 
+			$tasks[ $task_id ] = $task;
+
+		}
+
+		if ( empty( $tasks ) ) {
+			return false;
+		}
+
+		foreach ( $tasks as $task_id => $task ) {
 			if ( call_user_func_array( $task['callback'], array( $post_id, $task_id ) ) ) {
 				$completed_tasks[] = $task_id;
 			}
 		}
 
-		if ( empty( $this->tasks ) ) {
-			return false;
-		}
-
 		$checklist_data = array(
-			'tasks' => $this->tasks,
+			'tasks'     => $this->tasks,
 			'completed' => $completed_tasks,
 		);
 

--- a/tests/test-publishing-checklist.php
+++ b/tests/test-publishing-checklist.php
@@ -10,7 +10,7 @@ Maecenas nunc nisi, pulvinar dapibus sagittis non, accumsan id turpis.
 
 Nulla facilisi. Cras fringilla eu neque vitae sagittis. Aliquam vulputate, metus ut euismod ultricies, nunc neque convallis justo, eu blandit urna felis a nulla. Maecenas consectetur odio magna, eget eleifend ex accumsan non. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Cras eget neque neque. Morbi ut vehicula eros, eu feugiat orci. Suspendisse sodales nec nisl nec finibus. Nunc porta euismod justo et pellentesque. Mauris convallis elit eget ligula elementum aliquam. Duis consequat lacus nec nulla maximus, ac pharetra dui interdum. Mauris et est ut enim auctor euismod non in urna. Sed ut sollicitudin elit. Pellentesque maximus nisl vel nulla tempus, feugiat venenatis lorem convallis.
 
-Fusce tincidunt finibus mi vel porta. 
+Fusce tincidunt finibus mi vel porta.
 
 Fusce tincidunt finibus mi vel porta. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent at leo eu quam ullamcorper fermentum vel nec lorem. Praesent maximus aliquam felis. Suspendisse ac nisl velit. Aliquam non mattis magna, quis elementum elit. Etiam nulla augue, suscipit malesuada sollicitudin vitae, malesuada vitae risus. Sed diam eros, bibendum in condimentum ac, porta ullamcorper lorem. Praesent in dignissim ante, non auctor est. Quisque placerat.';
 
@@ -26,6 +26,7 @@ Fusce tincidunt finibus mi vel porta. Cum sociis natoque penatibus et magnis dis
 		parent::setUp();
 
 		self::$instance = new Publishing_Checklist;
+
 		$args = array(
 			'label'           => esc_html__( 'Word Count', 'publishing-checklist' ),
 			'callback'        => 'ensure_minimum_200_words',
@@ -33,6 +34,7 @@ Fusce tincidunt finibus mi vel porta. Cum sociis natoque penatibus et magnis dis
 			'post_type'       => array( 'post' ),
 		);
 		Publishing_Checklist()->register_task( 'test-publishing-checklist-word-count', $args );
+
 	}
 
 	public function test_incomplete_evaluate_checklist() {
@@ -53,6 +55,22 @@ Fusce tincidunt finibus mi vel porta. Cum sociis natoque penatibus et magnis dis
 		$this->assertContains( 'Word Count', $evaluated['tasks']['test-publishing-checklist-word-count']['label'] );
 		$this->assertContains( 'Posts should be at least 200 words.', $evaluated['tasks']['test-publishing-checklist-word-count']['explanation'] );
 		$this->assertContains( 'test-publishing-checklist-word-count', $evaluated['completed'] );
+	}
+
+	public function test_tasks_for_multiple_post_types() {
+
+		Publishing_Checklist()->register_task( 'test-pass-page', array(
+			'label'           => 'test',
+			'callback'        => '__return_true',
+			'post_type'       => array( 'page' ),
+		) );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$evaluated = Publishing_Checklist()->evaluate_checklist( $post_id );
+
+		$this->assertEquals( 1, count( $evaluated['tasks'] ) );
+		$this->assertTrue( in_array( 'test-pass-page', $evaluated['completed'] ) );
+
 	}
 
 	public function test_checklist_column_output_action() {

--- a/tests/test-publishing-checklist.php
+++ b/tests/test-publishing-checklist.php
@@ -69,7 +69,7 @@ Fusce tincidunt finibus mi vel porta. Cum sociis natoque penatibus et magnis dis
 		$evaluated = Publishing_Checklist()->evaluate_checklist( $post_id );
 
 		$this->assertEquals( 1, count( $evaluated['tasks'] ) );
-		$this->assertTrue( in_array( 'test-pass-page', $evaluated['completed'] ) );
+		$this->assertTrue( in_array( 'test-pass-page', $evaluated['completed'], true ) );
 
 	}
 


### PR DESCRIPTION
Currently there is a bug if you have some tasks registered for one post type, and different ones for another. The checklist will display incorrectly.

![image](https://cloud.githubusercontent.com/assets/494927/12945022/be358eca-cfe2-11e5-80f3-af0428dc1f0f.png)

Problem is with the evaluate_task method. It loops through `$this->tasks` and checks if applicable, unsetting the task from `$this->tasks` if not. However it then executes the callback regardless.

This could be easily fixed by adding `continue` after unsetting the task.

However I think a better solution is to create a list of tasks that are to be run for this post, and then separately iterate over them and run the callback.

Reason for this? Keeps the original tasks list in tact and would allows you to do things such as calling `execute_task` for multiple post types on the same page load. Or run certain tasks for certain posts - eg by category.
