### PR TITLE
Fix checklist column display on hierarchical CPTs list table

### DIFF
--- a/publishing-checklist.php
+++ b/publishing-checklist.php
@@ -58,10 +58,6 @@ class Publishing_Checklist {
 
 	}
 
-	private function get_supported_post_types() {
-
-	}
-
 	/**
 	 * Register a validation task for our publishing checklist
 	 *

--- a/publishing-checklist.php
+++ b/publishing-checklist.php
@@ -35,10 +35,31 @@ class Publishing_Checklist {
 	 * Set up actions for the plugin
 	 */
 	private function setup_actions() {
+
 		add_action( 'publishing_checklist_enqueue_scripts', array( $this, 'action_publishing_checklist_enqueue_scripts' ) );
 		add_action( 'post_submitbox_misc_actions', array( $this, 'action_post_submitbox_misc_actions_render_checklist' ) );
-		add_action( 'manage_posts_custom_column', array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
-		add_filter( 'manage_posts_columns', array( $this, 'filter_manage_posts_columns' ), 99 );
+
+		// Must be called before list table is rendered, but after all tasks have been registered.
+		add_action( 'admin_head', function() {
+
+			// Find all post types with tasks associated.
+			$post_types = array();
+			foreach ( $this->tasks as $task ) {
+				$post_types = array_unique( array_merge( $post_types, $task['post_type'] ) );
+			}
+
+			// Add post list table columns
+			foreach ( $post_types as $post_type ) {
+				add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
+				add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ), 99 );
+			}
+
+		} );
+
+	}
+
+	private function get_supported_post_types() {
+
 	}
 
 	/**


### PR DESCRIPTION
BUG: For custom post type, "publishing checklist" column header is showing on post list table but not the evaluated results.

Whats the problem? got to love the consistency of WP. 

the action `manage_posts_columns` is fired for all post types that are NOT `pages`.
the action `manage_posts_custom_column ` is fired for all post types that are NOT heriarchical

Notice that these are not the same ;) My post type is heirarchical but not a page, and only gets the latter.

Solution here?

Would be nice to add the action by post type, for all post types with tasks attached. This is OK as long as we hook in later (after tasks registered) but before rendering the post list table. 

What do you think of this solution?