### PR TITLE
Register columns on inline-save ajax action for quickedit

### DIFF
--- a/publishing-checklist.php
+++ b/publishing-checklist.php
@@ -40,22 +40,30 @@ class Publishing_Checklist {
 		add_action( 'post_submitbox_misc_actions', array( $this, 'action_post_submitbox_misc_actions_render_checklist' ) );
 
 		// Must be called before list table is rendered, but after all tasks have been registered.
-		add_action( 'admin_head', function() {
+		add_action( 'admin_head',          array( $this, 'register_custom_column_handlers' ) );
+		add_action( 'wp_ajax_inline-save', array( $this, 'register_custom_column_handlers' ), 1 );
+	}
 
-			// Find all post types with tasks associated.
-			$post_types = array();
-			foreach ( $this->tasks as $task ) {
-				$post_types = array_unique( array_merge( $post_types, $task['post_type'] ) );
-			}
+	/**
+	 * Register the Publishing Checklist column for list tables.
+	 *
+	 * Registers the Publishing Checklist column, and the custom column
+	 * rendering function, for all post types which have checklist tasks
+	 * defined.
+	 *
+	 */
+	public function register_custom_column_handlers() {
+		// Find all post types with tasks associated.
+		$post_types = array();
+		foreach ( $this->tasks as $task ) {
+			$post_types = array_unique( array_merge( $post_types, $task['post_type'] ) );
+		}
 
-			// Add post list table columns
-			foreach ( $post_types as $post_type ) {
-				add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
-				add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ), 99 );
-			}
-
-		} );
-
+		// Add post list table columns
+		foreach ( $post_types as $post_type ) {
+			add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'action_manage_posts_custom_column' ), 10, 2 );
+			add_filter( "manage_{$post_type}_posts_columns", array( $this, 'filter_manage_posts_columns' ), 99 );
+		}
 	}
 
 	/**

--- a/tests/test-publishing-checklist.php
+++ b/tests/test-publishing-checklist.php
@@ -10,7 +10,7 @@ Maecenas nunc nisi, pulvinar dapibus sagittis non, accumsan id turpis.
 
 Nulla facilisi. Cras fringilla eu neque vitae sagittis. Aliquam vulputate, metus ut euismod ultricies, nunc neque convallis justo, eu blandit urna felis a nulla. Maecenas consectetur odio magna, eget eleifend ex accumsan non. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Cras eget neque neque. Morbi ut vehicula eros, eu feugiat orci. Suspendisse sodales nec nisl nec finibus. Nunc porta euismod justo et pellentesque. Mauris convallis elit eget ligula elementum aliquam. Duis consequat lacus nec nulla maximus, ac pharetra dui interdum. Mauris et est ut enim auctor euismod non in urna. Sed ut sollicitudin elit. Pellentesque maximus nisl vel nulla tempus, feugiat venenatis lorem convallis.
 
-Fusce tincidunt finibus mi vel porta. 
+Fusce tincidunt finibus mi vel porta.
 
 Fusce tincidunt finibus mi vel porta. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Praesent at leo eu quam ullamcorper fermentum vel nec lorem. Praesent maximus aliquam felis. Suspendisse ac nisl velit. Aliquam non mattis magna, quis elementum elit. Etiam nulla augue, suscipit malesuada sollicitudin vitae, malesuada vitae risus. Sed diam eros, bibendum in condimentum ac, porta ullamcorper lorem. Praesent in dignissim ante, non auctor est. Quisque placerat.';
 
@@ -81,4 +81,23 @@ Fusce tincidunt finibus mi vel porta. Cum sociis natoque penatibus et magnis dis
 		$this->assertTrue( 'Publishing Checklist' === $columns['publishing_checklist'] );
 	}
 
+	public function test_quickedit_context() {
+		global $post;
+		$post_id = $this->factory->post->create(
+			array(
+				'post_content' => $this->long_test,
+			)
+		);
+		$post = get_post( $post_id );
+
+		do_action( 'wp_ajax_inline-save' );
+		$columns = apply_filters( 'manage_post_posts_columns', $this->columns );
+		$this->assertEquals( 'Publishing Checklist', $columns['publishing_checklist'] );
+
+		ob_start();
+		do_action( 'manage_post_posts_custom_column', 'publishing_checklist', $post_id );
+		$output = ob_get_clean();
+		$this->assertContains( '1 of 1 tasks complete', $output );
+
+	}
 }


### PR DESCRIPTION
In #30, we changed the registration of the Publishing Checklist column
to happen on `admin_head`, so that we could have access to all
registered post types and checklist tasks. This breaks the rendering of
the checklist column in quickedit saves, because the ajax response for
the quickedit save doesn't run the `admin_head` hook.

This change brings the quickedit response back in line with the initial
list table rendering, by running the same function on
`wp_ajax_inline-save` as is run on `admin_head`.