### PR TITLE
Add "required" task option

### DIFF
--- a/assets/css/publishing-checklist.css
+++ b/assets/css/publishing-checklist.css
@@ -11,6 +11,8 @@
     display: block; }
   .misc-pub-section.publishing-checklist li {
     cursor: help; }
+    .misc-pub-section.publishing-checklist li.required {
+      font-weight: bold; }
 
 @media screen and (max-width: 782px) {
   .column-publishing_checklist {

--- a/assets/css/scss/publishing-checklist.scss
+++ b/assets/css/scss/publishing-checklist.scss
@@ -14,6 +14,9 @@
 	}
 	li {
 		cursor: help;
+		&.required {
+			font-weight: bold;
+		}
 	}
 }
 .column-publishing_checklist {

--- a/templates/post-submitbox-misc-actions.php
+++ b/templates/post-submitbox-misc-actions.php
@@ -10,7 +10,8 @@
 	<div class="publishing-checklist-items" style="display:none;">
 		<ul>
 			<?php foreach ( $tasks as $id => $task ) : ?>
-				<li title="<?php echo esc_attr( $task['explanation'] ); ?>">
+			<li title="<?php echo esc_attr( $task['explanation'] ); ?>" class="<?php
+					echo esc_attr( $task['required'] ? 'required' : 'not-required' ); ?>">
 				<?php if ( in_array( $id, $completed_tasks, true ) ) : ?>
 					<span class="dashicons dashicons-yes"></span>
 				<?php else : ?>


### PR DESCRIPTION
Adds a setting field for "required" tasks which can be set when
registering tasks. If a task is registered with "required" => true, then
that task's callback must return true in order for a post to be
transitioned into publish or future status.

If a user attempts to publish a post which does not meet all required
tasks' requirements, the post will remain in its previous status and a
message will be displayed in admin notices alerting the user of the
condition(s) which must be met in order to publish the post.

"Required" tasks are also displayed first in the checklist, in bold text
for emphasis.
